### PR TITLE
add an array to loop through command

### DIFF
--- a/lint/action.yml
+++ b/lint/action.yml
@@ -14,21 +14,29 @@ runs:
         # Sets up array of targets
         IFS=' ' read -r -a targets <<< "${{ inputs.oscal-target }}"
 
+        lint_errors=0
+
         # Loop through each file and lint
         for target in "${targets[@]}"; do
           # Check if the file exists
           if [ ! -f "$target" ]; then
-            echo "File $target does not exist"
-            continue
+              echo "File $target does not exist"
+              lint_errors=$((lint_errors + 1))
+              continue
           fi
-
-        # Check if the file exists
-        if [ ! -f "$target" ]; then
-          echo "File $target does not exist"
-          exit 1
-        fi
 
         # Lint the file with Lula
           echo "Linting $target"
-          lula tools lint -f "$target"
+          lula tools lint -f "$target" || {
+              echo "Linting failed for $target"
+              lint_errors=$((lint_errors + 1))
+          }
         done
+
+        # Check if there were any lint errors
+        if [ "$lint_errors" -ne 0 ]; then
+            echo "Linting failed for one or more files."
+            exit 1
+        else
+            echo "All files linted successfully."
+        fi

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -11,8 +11,16 @@ runs:
     - shell: bash
       run: |
         #!/bin/bash
-        # Base url for zarf release artifacts
-        target="${{ inputs.oscal-target }}"
+        # Sets up array of targets
+        IFS=' ' read -r -a targets <<< "${{ inputs.oscal-target }}"
+
+        # Loop through each file and lint
+        for target in "${targets[@]}"; do
+          # Check if the file exists
+          if [ ! -f "$target" ]; then
+            echo "File $target does not exist"
+            continue
+          fi
 
         # Check if the file exists
         if [ ! -f "$target" ]; then
@@ -21,7 +29,6 @@ runs:
         fi
 
         # Lint the file with Lula
-        lula tools lint -f "$target"
-
-
-       
+          echo "Linting $target"
+          lula tools lint -f "$target"
+        done


### PR DESCRIPTION
Created a way to allow for multiple targets to be passed into the oscal-target to let Lula Lint multiple files without updating actual Lula/Go-OSCAL codebase.